### PR TITLE
fix: use match states to control visible panel

### DIFF
--- a/scripts/push.sh
+++ b/scripts/push.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 printf "\n\n######## game-ui push ########\n"
 
-IMAGE_REPOSITORY=${GAME_UI_IMAGE_REPOSITORY:-quay.io/redhatdemo/2021-game-ui:latest}
+IMAGE_REPOSITORY=${IMAGE_REPOSITORY:-quay.io/redhatdemo/2021-game-ui:latest}
 
 echo "Pushing ${IMAGE_REPOSITORY}"
 docker push ${IMAGE_REPOSITORY}

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -12,11 +12,11 @@ function App({ game, match }) {
 
   let view;
 
-  if (!match.playerA || !match.playerB) {
+  if (game.state === 'lobby') {
     view = <Lobby />;
   }
 
-  if (match.playerA && match.playerB) {
+  if (game.state === 'active') {
     view = <Main />;
   }
 

--- a/src/components/Battleship/Battleship.scss
+++ b/src/components/Battleship/Battleship.scss
@@ -354,15 +354,15 @@
   }
 
   .ship[type="destroyer"] {
-    background: url("./images/Destroyer.svg") no-repeat;
+    background: url("./images/destroyer.svg") no-repeat;
   }
   
   .ship[type="submarine"] {
-    background: url("./images/Submarine.svg") no-repeat;
+    background: url("./images/submarine.svg") no-repeat;
   }
   
   .ship[type="battleship"] {
-    background: url("./images/Battleship.svg") no-repeat;
+    background: url("./images/battleship.svg") no-repeat;
   }
 
   


### PR DESCRIPTION
@kylebuch8 salutations

I have a refactor that removes "playerA" and "playerB". It prevents players seeing the opponent UUID, but needs this small change in the React bits.

Edit: No rush on this BTW. It only becomes an issue when this is merged - https://github.com/rhdemo/2021-frontend-wss/pull/12